### PR TITLE
Update scaffolint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,10 @@
 # The linter file that doesn't lead junior developers to bad habits.
 # https://github.com/makersacademy/scaffolint
 #
-# Tested with Rubocop version 0.56.0
+# Problems (eg obselete names) may be due to an incompatible version.
+# Check your Rubocop version with `rubocop -v` in the command line.
+#
+# Tested with Rubocop version 0.71.0
 #
 # Introduction
 # ============
@@ -33,12 +36,9 @@
 # ==================
 #
 # Sometimes beginner devs interpret line or block length restrictions as a
-# reason to make things so abbreviated as to be unreadable. These messages are
-# designed to make you write more readable code - not less.
-
-Metrics/LineLength:
-  Max: 100
-
+# reason to make things so abbreviated as to be unreadable. These messages are
+# designed to make you write more readable code - not less.
+#
 # We want to encourage testing, but it can be verbose in the early stages.
 # So we'll give you a break. As you learn, try removing the next two sections.
 
@@ -46,6 +46,7 @@ Metrics/LineLength:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
+  Max: 100
 
 Metrics/BlockLength:
   Exclude:
@@ -56,7 +57,7 @@ Metrics/BlockLength:
 # ==========
 #
 # Many devs, upon running a linter for the first time, see a big wall of errors
-# of dubious necessity and put it in the 'way too much trouble' box. Beginners
+# of dubious necessity and put it in the 'way too much trouble' box. Beginners
 # usually have far more pressing concerns than which sort of quotes they use.
 #
 # This makes Rubocop have a bigger 'payoff' for beginners without so much of
@@ -286,7 +287,7 @@ FirstMethodArgumentLineBreak:
   Enabled: false
 FirstMethodParameterLineBreak:
   Enabled: false
-FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 FlipFlop:
   Enabled: false
@@ -310,11 +311,11 @@ IfWithSemicolon:
   Enabled: false
 ImplicitRuntimeError:
   Enabled: false
-IndentArray:
+IndentFirstArrayElement:
   Enabled: false
 IndentAssignment:
   Enabled: false
-IndentHash:
+IndentFirstHashElement:
   Enabled: false
 IndentHeredoc:
   Enabled: false


### PR DESCRIPTION
- Removes errors for 3 rules that have been renamed.
- Enable Metrics/LineLength/Max rule, which was being overwritten.

See https://github.com/makersacademy/scaffolint/pull/4 for details of the errors and warnings addressed.