### PR TITLE
Tidy project set up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ services:
   - postgresql
 
 before_script:
-  - psql -c 'create database chitter_test;' -U postgres
+  - psql -U postgres -c 'CREATE DATABASE chitter_test;'
 
 script:
   - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'rubocop', '0.71.0'
 
 group :test do
   gem 'rspec'
+  gem 'rubocop', '0.71.0'
   gem 'simplecov', require: false
   gem 'simplecov-console', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-
 group :test do
   gem 'rspec'
   gem 'rubocop', '0.71.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rake (13.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -50,7 +49,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
   rspec
   rubocop (= 0.71.0)
   simplecov

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,0 @@
-if ENV['RACK_ENV'] != 'production'
-  require 'rspec/core/rake_task'
-  
-  RSpec::Core::RakeTask.new :spec
-  
-  task default: [:spec]
-end


### PR DESCRIPTION
## Why

The project set up has some sources of dissonance. Let's reduce them so the focus can be on the stories.

- Rubocop gem should be in the test group in the Gemfile. Let's move it.
- The Travis CI config command to create database differs from the course material. Let's make it more similar so that it is more recognisable in a new context.
- Not all learners reach the course material on using Rake. Let's take it out so that using Rake tasks is optional.

## What

- [x] Move Rubocop gem into test group in Gemfile
- [x] Remove Rakefile
- [x] Reformat create database command in Travis CI config